### PR TITLE
Make split_layer_columns robust to non-string column labels (+ py3.12 cleanups)

### DIFF
--- a/emeraldtriangles/io/sql.py
+++ b/emeraldtriangles/io/sql.py
@@ -90,8 +90,8 @@ def read_sql(con, name, tri_id):
     triangles = pandasio.read_sql_query("select * from %s_triangles where tri_id = %%s" % name, params=(tri_id,), con=con)
     triangles_columns = pandasio.read_sql_query("select * from %s_triangles_columns where tri_id = %%s" % name, params=(tri_id,), con=con)
 
-    vertices_columns = vertices_columns.pivot("vertex_id", "column", "value")
-    triangles_columns = triangles_columns.pivot("triangle_id", "column", "value")
+    vertices_columns = vertices_columns.pivot(index="vertex_id", columns="column", values="value")
+    triangles_columns = triangles_columns.pivot(index="triangle_id", columns="column", values="value")
 
     vertices = vertices.set_index("vertex_id").sort_index().join(vertices_columns, rsuffix='_duplicate')
     triangles = triangles.set_index("triangle_id").sort_index().join(triangles_columns, rsuffix='_duplicate')

--- a/emeraldtriangles/io/vtk/volume.py
+++ b/emeraldtriangles/io/vtk/volume.py
@@ -11,13 +11,16 @@ import re
 logger = logging.getLogger(__name__)
 
 def split_layer_columns(df):
+    # Only string column labels can be per-layer ("name_0", "name_1", ...). Guard against
+    # non-string labels (e.g. a stray float/NaN column), which re.match cannot accept; these
+    # fall through to per_position_cols.
     per_layer_cols = [col for col in df.columns
-                      if re.match(r"^.*?[(\[]?[0-9]+[)\]]?$", col)]
+                      if isinstance(col, str) and re.match(r"^.*?[(\[]?[0-9]+[)\]]?$", col)]
     per_position_cols = [col for col in df.columns if not col in per_layer_cols]
 
     colgroups = {}
     for col in per_layer_cols:
-        group = re.match("^(.*?)[(\[]?[0-9]+[)\]]?$", col).groups()[0]
+        group = re.match(r"^(.*?)[(\[]?[0-9]+[)\]]?$", col).groups()[0]
         if group not in colgroups: colgroups[group] = []
         colgroups[group].append(col)
 
@@ -51,7 +54,7 @@ def split_layer_columns(df):
 
 
     def columns_to_layers(columns):
-        layers = np.array([int(re.match("^.*?[(\[]?([0-9]+)[)\]]?$", col).groups()[0]) for col in columns])
+        layers = np.array([int(re.match(r"^.*?[(\[]?([0-9]+)[)\]]?$", col).groups()[0]) for col in columns])
         layers -= np.min(layers)
         return dict(zip(columns, layers))
         
@@ -98,7 +101,7 @@ def to_meshdata(tin, layer_depths, x_col="X", y_col="Y", z_col="Z"):
             id_vars=['vertex_id'],
             value_name="%s_layer" % name,
             var_name="layer_id"
-        ).drop(columns=[] if idx is 0 else ["vertex_id", "layer_id"]))
+        ).drop(columns=[] if idx == 0 else ["vertex_id", "layer_id"]))
 
     df = pd.concat(dfs, axis=1)
     df = df.dropna(subset=["vertex_id", "layer_id"]).astype({"layer_id": int})


### PR DESCRIPTION
Fixes #28.

- **`split_layer_columns` non-string labels** — `re.match` was called on every
  column label assuming strings; a float/NaN label raised `TypeError: expected
  string or bytes-like object, got 'float'`. Now guarded with `isinstance(col, str)`;
  non-string labels fall through to per-position columns. Non-regressive on
  integer-suffixed per-layer columns.
- **Python 3.12** — regex literals made raw strings (clears `invalid escape
  sequence` SyntaxWarnings); `idx is 0` -> `idx == 0`.

(Also includes the pre-existing branch commit fixing positional `DataFrame.pivot()`
calls for pandas 2.x.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
