### PR TITLE
volume: validate cell-corner indices in to_meshdata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,17 @@ All notable changes to EMeraldTriangles are recorded here. This project uses
 loose [semantic versioning](https://semver.org/); the version string lives in
 `pyproject.toml`.
 
+## Unreleased
+
+* `io.vtk.volume.to_meshdata` now validates cell-corner indices instead of returning a float
+  index array that VTK later rejects with an opaque
+  `TypeError: Indices must be either a mask or an integer array-like`. Two checks:
+  * raise if `split_layer_columns` found no per-layer column groups at all;
+  * raise if any cell has NaN corner indices, reporting how many cells and which corners are
+    affected, and naming the usual cause (per-layer columns that fail to group because their
+    trailing layer index is not an integer, e.g. `res_0.0`).
+  A float-but-complete index array is cast back to int rather than rejected.
+
 ## 0.1.10 
 
 I think I may have included an unconmmitted local change in setup.py in v.0.1.9. Specifically, include_dirs was

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,9 @@ loose [semantic versioning](https://semver.org/); the version string lives in
   * raise if any cell has NaN corner indices, reporting how many cells and which corners are
     affected, and naming the usual cause (per-layer columns that fail to group because their
     trailing layer index is not an integer, e.g. `res_0.0`).
-  A float-but-complete index array is cast back to int rather than rejected.
+  A float-but-complete index array is cast back to int rather than rejected, with a warning:
+  the output mesh is unaffected, but the float dtype means integer IDs were promoted somewhere
+  upstream, so the repair leaves a breadcrumb instead of hiding it.
 
 ## 0.1.10 
 

--- a/emeraldtriangles/io/vtk/volume.py
+++ b/emeraldtriangles/io/vtk/volume.py
@@ -86,7 +86,13 @@ def _validate_cell_indices(cell_indices, corner_cols, point_arrays):
 
     missing = pd.isna(cell_indices)
     if not missing.any():
-        # Float dtype but every corner resolved -- safe to restore the integer indices VTK needs.
+        # Float dtype but every corner resolved -- safe to restore the integer indices VTK
+        # needs, but the float dtype itself means something upstream promoted integer IDs,
+        # so leave a breadcrumb rather than repairing it silently.
+        warnings.warn(
+            'Cell corner indices arrived as floats but are complete; cast back to integer. '
+            'The output mesh is unaffected, but this suggests vertex or layer IDs were '
+            'float-promoted somewhere upstream -- worth investigating if unexpected.')
         return cell_indices.astype(np.int64)
 
     incomplete = missing.any(axis=1)

--- a/emeraldtriangles/io/vtk/volume.py
+++ b/emeraldtriangles/io/vtk/volume.py
@@ -66,6 +66,44 @@ def split_layer_columns(df):
     return df[per_position_cols], colgroups
     
 
+def _validate_cell_indices(cell_indices, corner_cols, point_arrays):
+    """Check that every cell found all six of its corner points, and return integer indices.
+
+    The corner indices are produced by left-merging each cell corner against the melted
+    per-layer point table, so a corner whose (vertex_id, layer_id) pair is missing from that
+    table comes back as NaN -- which also promotes the whole array to float. VTK requires
+    integer indices, so an unchecked array surfaces much later as an opaque
+    ``TypeError: Indices must be either a mask or an integer array-like`` from pyvista, which
+    says nothing about the missing points. Fail here instead, naming the likely cause.
+
+    The usual cause is that the per-layer columns did not group: ``split_layer_columns``
+    matches a *trailing integer*, so columns named e.g. ``res_0.0`` (a float layer index
+    upstream) or ``label_nan`` are each treated as a single-member group and discarded,
+    leaving the melted table nearly empty.
+    """
+    if np.issubdtype(cell_indices.dtype, np.integer):
+        return cell_indices
+
+    missing = pd.isna(cell_indices)
+    if not missing.any():
+        # Float dtype but every corner resolved -- safe to restore the integer indices VTK needs.
+        return cell_indices.astype(np.int64)
+
+    incomplete = missing.any(axis=1)
+    per_corner = ', '.join(f'{name}={int(n)}'
+                           for name, n in zip(corner_cols, missing.sum(axis=0)))
+    n_layer_cols = sum(1 for col in point_arrays.columns if str(col).endswith('_layer'))
+    raise ValueError(
+        f'{int(incomplete.sum())} of {len(cell_indices)} cells '
+        f'({incomplete.mean():.1%}) reference points that are missing from the melted '
+        f'per-layer table, so their corner indices are NaN (missing per corner: {per_corner}). '
+        f'The melted table has {n_layer_cols} per-layer column(s) and {len(point_arrays)} rows. '
+        'This usually means the per-layer columns of tin["vertices"] did not group: '
+        'split_layer_columns groups on a trailing integer, so names like "res_0.0" or '
+        '"res_nan" are discarded as single-member groups. Check that the layer index used to '
+        'build those column names is an integer.')
+
+
 def to_meshdata(tin, layer_depths, x_col="X", y_col="Y", z_col="Z"):
     """Layer depths is a list of offsets from z_col. Values are
     subtracted from z_col, so positive numbers mean downwards."""
@@ -93,6 +131,13 @@ def to_meshdata(tin, layer_depths, x_col="X", y_col="Y", z_col="Z"):
 
     vertices['vertex_id'] = vertices.index
     vertices, per_layer_dfs =  split_layer_columns(vertices)
+    if not per_layer_dfs:
+        raise ValueError(
+            'No per-layer columns were found on tin["vertices"], so there is no depth data to '
+            'build a volume from. split_layer_columns groups columns on a *trailing integer*, so '
+            'names like "res_0.0" (a float layer index upstream) or "res_nan" are each treated as '
+            'a single-member group and discarded. Check that the layer index used to build these '
+            'column names is an integer.')
     dfs = []
     for idx, (name, per_layer_df) in enumerate(per_layer_dfs.items()):
         dfs.append(per_layer_df.assign(
@@ -158,7 +203,8 @@ def to_meshdata(tin, layer_depths, x_col="X", y_col="Y", z_col="Z"):
     # Reformat geometry for vtk output
     
     point_coordinates = df[[x_col, y_col, 'point_z']].to_numpy()
-    cell_indices_np = df_cell[['0_3d', '1_3d', '2_3d', '3_3d', '4_3d', '5_3d']].to_numpy()
+    corner_cols = ['0_3d', '1_3d', '2_3d', '3_3d', '4_3d', '5_3d']
+    cell_indices_np = _validate_cell_indices(df_cell[corner_cols].to_numpy(), corner_cols, df)
     num_nodes = np.full((cell_indices_np.shape[0], 1), 6, dtype=np.int64)
 
     cells_out_vtk = np.concatenate( (num_nodes,cell_indices_np), axis=1)

--- a/tests/test_volume_cell_indices.py
+++ b/tests/test_volume_cell_indices.py
@@ -1,0 +1,94 @@
+"""Tests for cell-corner index validation in emeraldtriangles.io.vtk.volume.to_meshdata.
+
+The corner indices come from left-merging each cell corner against the melted per-layer point
+table. A corner whose (vertex_id, layer_id) pair is missing comes back NaN, which promotes the
+index array to float. VTK needs integers, so without a check this surfaces much later as an
+opaque pyvista ``TypeError: Indices must be either a mask or an integer array-like``.
+
+The usual upstream cause is per-layer columns that fail to group -- ``split_layer_columns``
+matches a trailing integer, so ``res_0.0`` (from a float layer index upstream) is treated as a
+single-member group and discarded.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from emeraldtriangles.io.vtk.volume import _validate_cell_indices, to_meshdata
+
+LAYER_DEPTHS = [-5.0, -15.0, -25.0]
+CORNER_COLS = ['0_3d', '1_3d', '2_3d', '3_3d', '4_3d', '5_3d']
+
+
+def _tin(layer_suffixes=('0', '1', '2')):
+    """Square of four vertices split into two triangles, with three per-layer `res` columns."""
+    vertices = pd.DataFrame({
+        'X': [0.0, 1.0, 1.0, 0.0],
+        'Y': [0.0, 0.0, 1.0, 1.0],
+        'Z': [100.0, 101.0, 102.0, 103.0],
+    })
+    for i, suffix in enumerate(layer_suffixes):
+        vertices[f'res_{suffix}'] = np.arange(len(vertices), dtype=float) + i
+    triangles = pd.DataFrame({0: [0, 0], 1: [1, 2], 2: [2, 3]})
+    return {'vertices': vertices, 'triangles': triangles, 'meta': {'layer_depths': LAYER_DEPTHS}}
+
+
+def test_integer_layer_suffixes_give_integer_cells():
+    meshdata = to_meshdata(_tin(), LAYER_DEPTHS, x_col='X', y_col='Y', z_col='Z')
+    cells = meshdata['cells']
+    assert np.issubdtype(cells.dtype, np.integer)
+    assert cells.shape == (len(_tin()['triangles']) * len(LAYER_DEPTHS), 7)
+    assert (cells[:, 0] == 6).all()
+
+
+def test_float_layer_suffixes_lose_every_group():
+    """`res_0.0` style names are all discarded by split_layer_columns: nothing left to stack."""
+    tin = _tin(layer_suffixes=('0.0', '1.0', '2.0'))
+    with pytest.raises(ValueError) as excinfo:
+        to_meshdata(tin, LAYER_DEPTHS, x_col='X', y_col='Y', z_col='Z')
+    message = str(excinfo.value)
+    assert 'No per-layer columns were found' in message
+    assert 'trailing integer' in message
+
+
+def test_short_surviving_group_reports_missing_corners():
+    """The real-world shape: the genuine per-layer columns are lost to float suffixes, and a
+    shorter non-layer group (`dist_corner_0`/`dist_corner_1`) survives and defines the melt.
+    Cells then reference layers the melted table never had."""
+    tin = _tin(layer_suffixes=('0.0', '1.0', '2.0'))
+    tin['vertices']['dist_corner_0'] = 1.0
+    tin['vertices']['dist_corner_1'] = 2.0
+    with pytest.raises(ValueError) as excinfo:
+        to_meshdata(tin, LAYER_DEPTHS, x_col='X', y_col='Y', z_col='Z')
+    message = str(excinfo.value)
+    assert 'corner indices are NaN' in message
+    assert 'trailing integer' in message
+
+
+def test_validate_cell_indices_passes_integers_through():
+    cells = np.arange(12, dtype=np.int64).reshape(2, 6)
+    out = _validate_cell_indices(cells, CORNER_COLS, pd.DataFrame({'res_layer': [0.0]}))
+    assert out is cells
+
+
+def test_validate_cell_indices_restores_complete_float_arrays():
+    cells = np.arange(12, dtype=float).reshape(2, 6)
+    out = _validate_cell_indices(cells, CORNER_COLS, pd.DataFrame({'res_layer': [0.0]}))
+    assert np.issubdtype(out.dtype, np.integer)
+    assert np.array_equal(out, cells.astype(np.int64))
+
+
+def test_validate_cell_indices_reports_which_corners_are_missing():
+    cells = np.arange(12, dtype=float).reshape(2, 6)
+    cells[1, 3] = np.nan
+    with pytest.raises(ValueError) as excinfo:
+        _validate_cell_indices(cells, CORNER_COLS, pd.DataFrame({'res_layer': [0.0]}))
+    message = str(excinfo.value)
+    assert '1 of 2 cells' in message
+    assert '3_3d=1' in message
+
+
+if __name__ == '__main__':
+    test_integer_layer_suffixes_give_integer_cells()
+    test_validate_cell_indices_passes_integers_through()
+    test_validate_cell_indices_restores_complete_float_arrays()
+    print('all ok')

--- a/tests/test_volume_cell_indices.py
+++ b/tests/test_volume_cell_indices.py
@@ -70,9 +70,12 @@ def test_validate_cell_indices_passes_integers_through():
     assert out is cells
 
 
-def test_validate_cell_indices_restores_complete_float_arrays():
+def test_validate_cell_indices_restores_complete_float_arrays_with_a_warning():
+    """The cast is safe (the mesh is complete), but the float dtype means integer IDs were
+    promoted somewhere upstream, so the repair must leave a breadcrumb."""
     cells = np.arange(12, dtype=float).reshape(2, 6)
-    out = _validate_cell_indices(cells, CORNER_COLS, pd.DataFrame({'res_layer': [0.0]}))
+    with pytest.warns(UserWarning, match='cast back to integer'):
+        out = _validate_cell_indices(cells, CORNER_COLS, pd.DataFrame({'res_layer': [0.0]}))
     assert np.issubdtype(out.dtype, np.integer)
     assert np.array_equal(out, cells.astype(np.int64))
 
@@ -90,5 +93,5 @@ def test_validate_cell_indices_reports_which_corners_are_missing():
 if __name__ == '__main__':
     test_integer_layer_suffixes_give_integer_cells()
     test_validate_cell_indices_passes_integers_through()
-    test_validate_cell_indices_restores_complete_float_arrays()
+    test_validate_cell_indices_restores_complete_float_arrays_with_a_warning()
     print('all ok')


### PR DESCRIPTION
## Problem

`to_meshdata` builds each cell's six corner indices by left-merging against the melted per-layer point table. A corner whose `(vertex_id, layer_id)` pair is missing comes back `NaN`, which promotes the whole index array to float. VTK requires integer indices, so the failure surfaces several frames later inside pyvista as:

```
TypeError: Indices must be either a mask or an integer array-like
```

That message says nothing about missing points, missing layers, or the column names that actually caused it. Diagnosing one real instance took a full debugging session before the cause turned out to be a float `layer` column three packages upstream.

## Change

Two checks in `to_meshdata`:

1. **No per-layer groups at all** → raise immediately. `split_layer_columns` groups on a *trailing integer*, so columns named `res_0.0` (a float layer index upstream) or `res_nan` are each treated as a single-member group and discarded. Previously this reached `pd.concat([])` and died with `No objects to concatenate`.
2. **Any cell with NaN corner indices** → raise, reporting how many cells are affected, the per-corner NaN counts, and the size of the melted table, and naming the usual upstream cause.

A float-but-complete index array is cast back to `int64` rather than rejected — that is safe, and was accepted by older pyvista.

## Note

This is a diagnostics change: meshes that build correctly today are unaffected (integer index arrays return unchanged on the first line). It converts a confusing late failure into an early one that names the cause.

## Tests

`tests/test_volume_cell_indices.py`, 6 cases covering the happy path, both raise paths (including the real-world shape where a short non-layer group survives and defines the melt), and the float-but-complete cast. Full suite green (9 passed).

## Related

The root cause of the instance that prompted this is fixed in emerald-algorithms-elnes (`reshaper`: restore integer `layer` dtype), with the upstream naming collision addressed in emerald-database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)