### PR TITLE
cleanup: geometric triangle filter (area / side length / perimeter / angle / aspect) and points_to_tin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ All notable changes to EMeraldTriangles are recorded here. This project uses
 loose [semantic versioning](https://semver.org/); the version string lives in
 `pyproject.toml`.
 
-## Unreleased
+## 0.1.11
 
 * New geometric triangle filter (issue #33, the geometric half of #20):
   `cleanup.triangle_metrics(vertices, triangles)` (area, perimeter, max/min side length, min angle, aspect) and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,19 @@ loose [semantic versioning](https://semver.org/); the version string lives in
 
 ## Unreleased
 
+* New geometric triangle filter (issue #33, the geometric half of #20):
+  `cleanup.triangle_metrics(vertices, triangles)` (area, perimeter, max/min side length, min angle, aspect) and
+  `cleanup.remove_triangles_by_shape(max_side_length=, max_area=, max_perimeter=, min_angle_deg=, max_aspect=, **tri)`
+  to drop the sliver triangles that `supplant_triangles` creates across concave footprints and gaps; the kept
+  triangles are re-indexed, vertices untouched (`remove_unused_vertices` afterwards if wanted).
+* `refine_mesh.points_to_tin(points, boundary=None, existing_boundary=False)` — the usual
+  `replace_triangles` + `supplant_triangles` pair for a table of points, with an optional footprint polygon (only
+  triangles whose centroid lies inside are kept).
+* `cleanup.remove_unused_vertices` no longer writes the remapped vertex ids into the caller's `triangles` /
+  `segments` frames with an in-place `.loc[:, [0, 1, 2]] = ...` (int64/float64 into int32 columns: a FutureWarning on
+  pandas 2, an error on pandas 3, #26); it now returns new frames with an `int64` dtype (float64 with NaN only if an
+  id could not be mapped). The returned dict is unchanged; callers that relied on the in-place mutation of the
+  input frames must use the return value.
 * `io.vtk.volume.to_meshdata` now validates cell-corner indices instead of returning a float
   index array that VTK later rejects with an opaque
   `TypeError: Indices must be either a mask or an integer array-like`. Two checks:

--- a/emeraldtriangles/cleanup.py
+++ b/emeraldtriangles/cleanup.py
@@ -122,20 +122,24 @@ def remove_unused_vertices(**tri):
 
     new_index_mapping = dict(zip(v_subset.loc[:, index_orig_name].values, v_subset.index.values))
 
-    triangles_copy = tri['triangles'].loc[:, [0, 1, 2]].copy()
-    for col in triangles_copy.columns:
-        triangles_copy[col] = triangles_copy[col].map(new_index_mapping)
-
+    # Whole-column assignment on copies: the old ``.loc[:, [0, 1, 2]] = ...`` wrote int64 (or float64 when a key
+    # was missing) into int32 columns in place -- a FutureWarning on pandas 2 and an error on pandas 3 (#26).
+    tri['triangles'] = _remap_index_columns(tri['triangles'], [0, 1, 2], new_index_mapping)
     if 'segments' in tri.keys():
-        segments_copy = tri['segments'].loc[:, [0, 1]].copy()
-        for col in segments_copy.columns:
-            segments_copy[col] = segments_copy[col].map(new_index_mapping)
-        tri['segments'].loc[:, [0, 1]] = segments_copy
-
+        tri['segments'] = _remap_index_columns(tri['segments'], [0, 1], new_index_mapping)
     tri['vertices'] = v_subset
-    tri['triangles'].loc[:, [0, 1, 2]] = triangles_copy
 
     return tri
+
+
+def _remap_index_columns(df, columns, mapping):
+    """Return a copy of ``df`` with the vertex-id ``columns`` remapped through ``mapping`` (dtype int64 when every
+    id is known, float64 with NaN otherwise)."""
+    out = df.copy()
+    for col in columns:
+        mapped = out[col].map(mapping)
+        out[col] = mapped.astype("int64") if mapped.notna().all() else mapped.astype("float64")
+    return out
 
 def remove_invalid_triangles(points, faces):
     """
@@ -178,3 +182,82 @@ def set_case_column_names(df, columns, uppercase=True, ):
             raise ValueError(f"both uppercase and lower versions of the column {col} found in this DataFrame!")
         if function_target(col) not in df.columns:
             df.rename(columns={function_source(col): function_target(col)}, inplace=True)
+
+
+# ----------------------------------------------------------------------------------------------------------------
+# geometric quality of triangles (issue #20, #33)
+# ----------------------------------------------------------------------------------------------------------------
+
+def triangle_metrics(vertices, triangles, x_col="X", y_col="Y"):
+    """Per-triangle shape metrics as a DataFrame aligned with ``triangles``.
+
+    Columns: ``area``, ``perimeter``, ``max_side_length``, ``min_side_length``, ``min_angle_deg`` and ``aspect``
+    (longest side over the diameter of the inscribed circle; 1.73 for an equilateral triangle, large for slivers).
+    ``triangles[[0, 1, 2]]`` are taken as *positions* into ``vertices`` (the natural 0..n-1 index that
+    :func:`reindex` produces); call :func:`reindex` first if the vertex index has gaps.
+    """
+    idx = triangles.loc[:, [0, 1, 2]].to_numpy(dtype=np.int64)
+    if idx.size and (idx.min() < 0 or idx.max() >= len(vertices)):
+        raise ValueError("triangles reference vertex positions outside the vertex table; reindex() first")
+    xt = vertices[x_col].to_numpy(dtype=float)[idx]
+    yt = vertices[y_col].to_numpy(dtype=float)[idx]
+    area = 0.5 * np.abs((xt[:, 2] - xt[:, 1]) * (yt[:, 0] - yt[:, 1]) - (xt[:, 0] - xt[:, 1]) * (yt[:, 2] - yt[:, 1]))
+    # side i is opposite vertex i
+    sides = np.empty_like(xt)
+    sides[:, 0] = np.hypot(xt[:, 1] - xt[:, 2], yt[:, 1] - yt[:, 2])
+    sides[:, 1] = np.hypot(xt[:, 0] - xt[:, 2], yt[:, 0] - yt[:, 2])
+    sides[:, 2] = np.hypot(xt[:, 0] - xt[:, 1], yt[:, 0] - yt[:, 1])
+    a, b, c = sides[:, 0], sides[:, 1], sides[:, 2]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        cosines = np.stack([(b ** 2 + c ** 2 - a ** 2) / (2 * b * c),
+                            (a ** 2 + c ** 2 - b ** 2) / (2 * a * c),
+                            (a ** 2 + b ** 2 - c ** 2) / (2 * a * b)], axis=1)
+        angles = np.degrees(np.arccos(np.clip(cosines, -1.0, 1.0)))
+        perimeter = sides.sum(axis=1)
+        inradius = np.where(perimeter > 0, 2.0 * area / perimeter, 0.0)      # r = area / semi-perimeter
+        aspect = np.where(inradius > 0, sides.max(axis=1) / (2.0 * inradius), np.inf)
+    return pd.DataFrame({"area": area, "perimeter": perimeter, "max_side_length": sides.max(axis=1),
+                         "min_side_length": sides.min(axis=1), "min_angle_deg": np.nanmin(angles, axis=1),
+                         "aspect": aspect}, index=triangles.index)
+
+
+def remove_triangles_by_shape(*, max_side_length=None, max_area=None, max_perimeter=None, min_angle_deg=None,
+                              max_aspect=None, keep_metrics=False, x_col="X", y_col="Y", **tri):
+    """Drop triangles that fail any of the given shape criteria; return a new tri dict.
+
+    Typical use: after ``supplant_triangles(existing_boundary=False)`` the mesh reaches out to the convex hull of the
+    vertices, so concave footprints and interior gaps are spanned by long, thin triangles. For vertices on a regular
+    lattice with spacing ``dx, dy`` the legitimate triangles have ``max_side_length <= hypot(dx, dy)`` and
+    ``area <= dx*dy/2``; thresholds a few percent above those remove exactly the spanning triangles.
+
+    Parameters
+    ----------
+    max_side_length, max_area, max_perimeter : float, optional -- upper bounds
+    min_angle_deg : float, optional -- smallest internal angle allowed (slivers have tiny angles)
+    max_aspect : float, optional -- upper bound on ``max_side_length / (2 * inradius)``
+    keep_metrics : bool -- append the metric columns to the returned ``triangles``
+    **tri : the tin dict (``vertices``, ``triangles``, and anything else, which is passed through)
+
+    Triangles are re-indexed to 0..n-1; vertices are untouched (use :func:`remove_unused_vertices` afterwards to
+    drop vertices that no triangle references).
+    """
+    vertices, triangles = tri["vertices"], tri["triangles"]
+    m = triangle_metrics(vertices, triangles, x_col=x_col, y_col=y_col)
+    keep = np.ones(len(triangles), dtype=bool)
+    if max_side_length is not None:
+        keep &= m["max_side_length"].to_numpy() <= max_side_length
+    if max_area is not None:
+        keep &= m["area"].to_numpy() <= max_area
+    if max_perimeter is not None:
+        keep &= m["perimeter"].to_numpy() <= max_perimeter
+    if min_angle_deg is not None:
+        keep &= m["min_angle_deg"].to_numpy() >= min_angle_deg
+    if max_aspect is not None:
+        keep &= m["aspect"].to_numpy() <= max_aspect
+    out = dict(tri)
+    kept = triangles.loc[keep]
+    if keep_metrics:
+        kept = pd.concat([kept, m.loc[keep]], axis=1)
+    out["triangles"] = kept.reset_index(drop=True)
+    out["n_triangles_removed"] = int((~keep).sum())
+    return out

--- a/emeraldtriangles/refine_mesh.py
+++ b/emeraldtriangles/refine_mesh.py
@@ -196,3 +196,30 @@ def interpolate_vertices(tri, to_interpolate_idxs):
     cols = list(set(interpolated.columns).intersection(set(tri["vertices"].columns)) - no_interpolation)
     res["vertices"].loc[interpolated.index, cols] = interpolated[cols]
     return res
+
+
+def points_to_tin(points, boundary=None, existing_boundary=False, x_col="X", y_col="Y"):
+    """Triangulate a table of points into a tin dict -- the usual ``replace_triangles`` + ``supplant_triangles`` pair.
+
+    ``points``: DataFrame with ``x_col``/``y_col`` (renamed to ``X``/``Y`` if needed) and any attribute columns,
+    which become vertex columns. ``boundary``: optional shapely (Multi)Polygon -- only triangles whose centroid lies
+    inside it are kept (the convex-hull triangles outside a concave footprint go). ``existing_boundary`` is passed
+    to ``supplant_triangles``. Returns the tin dict (``vertices``, ``triangles``, plus whatever the triangulation
+    added, e.g. ``segments``); combine with ``cleanup.remove_triangles_by_shape`` to drop slivers across gaps.
+    """
+    pts = points.reset_index(drop=True).copy()
+    if x_col != "X" or y_col != "Y":
+        pts = pts.rename(columns={x_col: "X", y_col: "Y"})
+    tri = {"points": pts, "vertices": pd.DataFrame({"X": [], "Y": []}),
+           "triangles": pd.DataFrame({0: [], 1: [], 2: []})}
+    tri = replace_triangles(**tri)
+    tri = supplant_triangles(existing_boundary=existing_boundary, **tri)
+    if boundary is not None:
+        import shapely
+        idx = tri["triangles"].loc[:, [0, 1, 2]].to_numpy(dtype=np.int64)
+        cx = tri["vertices"]["X"].to_numpy(dtype=float)[idx].mean(axis=1)
+        cy = tri["vertices"]["Y"].to_numpy(dtype=float)[idx].mean(axis=1)
+        inside = shapely.contains_xy(boundary, cx, cy)
+        tri["triangles"] = tri["triangles"].loc[inside].reset_index(drop=True)
+    tri.pop("points", None)
+    return tri

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emeraldtriangles"
-version = "0.1.10"
+version = "0.1.11"
 description = "Triangle mesh transforms"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cleanup_shape_filter.py
+++ b/tests/test_cleanup_shape_filter.py
@@ -1,0 +1,117 @@
+"""Tests for the geometric triangle filter (issue #33) and the remove_unused_vertices dtype fix (#26)."""
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import emeraldtriangles as et
+from emeraldtriangles import cleanup, refine_mesh
+
+
+def _right_triangle_tin():
+    # 3-4-5 right triangle: area 6, perimeter 12, angles 36.87 / 53.13 / 90 degrees
+    vertices = pd.DataFrame({"X": [0.0, 4.0, 0.0], "Y": [0.0, 0.0, 3.0]})
+    triangles = pd.DataFrame({0: [0], 1: [1], 2: [2]})
+    return {"vertices": vertices, "triangles": triangles}
+
+
+def _lattice_points(nx=6, ny=5, dx=10.0, dy=10.0, hole=((2, 4), (2, 4))):
+    ix, iy = np.meshgrid(np.arange(nx), np.arange(ny), indexing="ij")
+    pts = pd.DataFrame({"X": ix.ravel() * dx, "Y": iy.ravel() * dy, "value": (ix * 10 + iy).ravel().astype(float)})
+    if hole is not None:
+        (x0, x1), (y0, y1) = hole
+        keep = ~((ix.ravel() >= x0) & (ix.ravel() < x1) & (iy.ravel() >= y0) & (iy.ravel() < y1))
+        pts = pts.loc[keep].reset_index(drop=True)
+    return pts
+
+
+def test_triangle_metrics_hand_computed():
+    tin = _right_triangle_tin()
+    m = cleanup.triangle_metrics(tin["vertices"], tin["triangles"])
+    assert m.index.equals(tin["triangles"].index)
+    assert np.isclose(m.loc[0, "area"], 6.0)
+    assert np.isclose(m.loc[0, "perimeter"], 12.0)
+    assert np.isclose(m.loc[0, "max_side_length"], 5.0)
+    assert np.isclose(m.loc[0, "min_side_length"], 3.0)
+    assert np.isclose(m.loc[0, "min_angle_deg"], np.degrees(np.arctan(3 / 4)))
+    # inradius of a 3-4-5 triangle is 1 -> aspect = 5 / 2
+    assert np.isclose(m.loc[0, "aspect"], 2.5)
+
+
+def test_triangle_metrics_degenerate_and_bad_index():
+    vertices = pd.DataFrame({"X": [0.0, 1.0, 2.0], "Y": [0.0, 0.0, 0.0]})
+    m = cleanup.triangle_metrics(vertices, pd.DataFrame({0: [0], 1: [1], 2: [2]}))
+    assert m.loc[0, "area"] == 0 and np.isinf(m.loc[0, "aspect"])
+    with pytest.raises(ValueError, match="reindex"):
+        cleanup.triangle_metrics(vertices, pd.DataFrame({0: [0], 1: [1], 2: [7]}))
+
+
+def test_remove_triangles_by_shape_removes_hull_slivers():
+    pts = _lattice_points()
+    tin = refine_mesh.points_to_tin(pts)
+    m0 = cleanup.triangle_metrics(tin["vertices"], tin["triangles"])
+    assert m0["max_side_length"].max() > np.hypot(10, 10) + 1e-6     # the hole is spanned
+    out = cleanup.remove_triangles_by_shape(max_side_length=1.05 * np.hypot(10, 10), **tin)
+    m1 = cleanup.triangle_metrics(out["vertices"], out["triangles"])
+    assert m1["max_side_length"].max() <= 1.05 * np.hypot(10, 10)
+    assert out["n_triangles_removed"] >= 1
+    assert len(out["triangles"]) + out["n_triangles_removed"] == len(tin["triangles"])
+    assert out["triangles"].index.equals(pd.RangeIndex(len(out["triangles"])))
+    # vertices untouched; other keys passed through
+    assert out["vertices"] is tin["vertices"]
+    assert set(tin) <= set(out)
+    # no triangle centroid inside the hole any more
+    idx = out["triangles"][[0, 1, 2]].to_numpy()
+    cx = out["vertices"]["X"].to_numpy()[idx].mean(axis=1)
+    cy = out["vertices"]["Y"].to_numpy()[idx].mean(axis=1)
+    assert not ((cx > 20) & (cx < 30) & (cy > 20) & (cy < 30)).any()
+
+
+def test_remove_triangles_by_shape_criteria_and_metrics():
+    pts = _lattice_points(hole=None)
+    tin = refine_mesh.points_to_tin(pts)
+    full = cleanup.remove_triangles_by_shape(**tin)
+    assert full["n_triangles_removed"] == 0 and len(full["triangles"]) == len(tin["triangles"])
+    by_area = cleanup.remove_triangles_by_shape(max_area=49.0, **tin)          # regular triangles have area 50
+    assert len(by_area["triangles"]) == 0
+    by_angle = cleanup.remove_triangles_by_shape(min_angle_deg=44.0, **tin)    # right isosceles: 45 degrees
+    assert len(by_angle["triangles"]) == len(tin["triangles"])
+    by_aspect = cleanup.remove_triangles_by_shape(max_aspect=2.0, **tin)       # right isosceles aspect ~ 2.41
+    assert len(by_aspect["triangles"]) == 0
+    with_metrics = cleanup.remove_triangles_by_shape(keep_metrics=True, **tin)
+    assert {"area", "perimeter", "max_side_length", "min_angle_deg", "aspect"} <= set(with_metrics["triangles"].columns)
+    assert et.remove_triangles_by_shape is cleanup.remove_triangles_by_shape      # star-exported
+
+
+def test_points_to_tin_with_boundary_and_attributes():
+    shapely = pytest.importorskip("shapely")
+    pts = _lattice_points(hole=None).rename(columns={"X": "x", "Y": "y"})
+    tin = refine_mesh.points_to_tin(pts, x_col="x", y_col="y")
+    assert {"X", "Y", "value"} <= set(tin["vertices"].columns)
+    assert len(tin["vertices"]) == len(pts) and "points" not in tin
+    np.testing.assert_allclose(np.sort(tin["vertices"]["value"]), np.sort(pts["value"]))
+    poly = shapely.geometry.box(0, 0, 25, 40)
+    clipped = refine_mesh.points_to_tin(pts, boundary=poly, x_col="x", y_col="y")
+    idx = clipped["triangles"][[0, 1, 2]].to_numpy()
+    cx = clipped["vertices"]["X"].to_numpy()[idx].mean(axis=1)
+    assert (cx < 25).all() and len(clipped["triangles"]) < len(tin["triangles"])
+    assert et.points_to_tin is refine_mesh.points_to_tin
+
+
+def test_remove_unused_vertices_int32_no_dtype_warning():
+    pts = _lattice_points()
+    tin = refine_mesh.points_to_tin(pts)
+    out = cleanup.remove_triangles_by_shape(max_side_length=1.05 * np.hypot(10, 10), **tin)
+    # emulate the `triangle` library's int32 ids and drop a corner vertex so something is unused
+    tri = {"vertices": out["vertices"], "triangles": out["triangles"][[0, 1, 2]].astype("int32")}
+    tri["triangles"] = tri["triangles"].iloc[:-3].reset_index(drop=True)
+    used_before = set(tri["triangles"].to_numpy().ravel())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        res = cleanup.remove_unused_vertices(**tri)
+    assert len(res["vertices"]) == len(used_before)
+    assert res["triangles"][[0, 1, 2]].dtypes.unique().tolist() == [np.dtype("int64")]
+    assert res["triangles"][[0, 1, 2]].to_numpy().max() < len(res["vertices"])
+    # the input triangles frame is not mutated any more
+    assert tri["triangles"].dtypes.unique().tolist() == [np.dtype("int32")]


### PR DESCRIPTION
Closes #33 — the geometric half of #20 — and the `cleanup.py` setitem item of #26.

## What

- `cleanup.triangle_metrics(vertices, triangles)` → DataFrame aligned with `triangles`: `area`, `perimeter`,
  `max_side_length`, `min_side_length`, `min_angle_deg`, `aspect` (longest side over the inscribed-circle diameter).
  Vectorised on vertex positions; raises if a triangle references a position outside the vertex table (reindex first).
- `cleanup.remove_triangles_by_shape(*, max_side_length=None, max_area=None, max_perimeter=None, min_angle_deg=None,
  max_aspect=None, keep_metrics=False, **tri)` → new tri dict with the failing triangles dropped and the rest
  re-indexed 0..n-1; vertices untouched (`remove_unused_vertices` afterwards if wanted); `n_triangles_removed` reported.
  For vertices on a regular lattice `dx, dy`, thresholds a few percent above `hypot(dx, dy)` / `dx*dy/2` remove exactly
  the hull-spanning slivers that `supplant_triangles(existing_boundary=False)` creates across concave footprints and gaps.
- `refine_mesh.points_to_tin(points, boundary=None, existing_boundary=False, x_col="X", y_col="Y")` — the standard
  `replace_triangles` + `supplant_triangles` pair for a table of points (attribute columns become vertex columns),
  with an optional shapely footprint polygon (only triangles whose centroid lies inside are kept).
- `cleanup.remove_unused_vertices`: the remapped vertex ids are now assigned as new `int64` frames instead of an in-place
  `.loc[:, [0, 1, 2]] = ...` into the int32 columns that `triangle` returns — a `FutureWarning` on pandas 2 and an error
  on pandas 3. Return value unchanged; the input frames are no longer mutated (callers relying on that side effect must
  use the return value — noted in CHANGES).

## Tests

`tests/test_cleanup_shape_filter.py` (6 tests): hand-computed metrics on a 3-4-5 triangle, degenerate / bad-index
cases, a lattice with a hole (slivers removed, footprint respected), each criterion singly and `keep_metrics`,
`points_to_tin` with attributes and a boundary, and `remove_unused_vertices` on int32 ids under
`warnings.simplefilter("error", FutureWarning)`. Full suite: 15 passed.

## Versioning

Bumps the version to **0.1.11**, which ships together with the already-merged #32 (cell-index validation); CHANGES.md's *Unreleased* section becomes the 0.1.11 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)